### PR TITLE
修复换源Bug

### DIFF
--- a/app/src/main/java/com/termux/zerocore/code/CodeString.kt
+++ b/app/src/main/java/com/termux/zerocore/code/CodeString.kt
@@ -10,20 +10,14 @@ package com.termux.zerocore.code
 public object CodeString {
 
 
-    public val QH:String = "sed -i 's@^\\(deb.*stable main\\)$@#\\1\\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list && sed -i 's@^\\(deb.*games stable\\)$@#\\1\\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/game-packages-24 games stable@' \$PREFIX/etc/apt/sources.list.d/game.list && sed -i 's@^\\(deb.*science stable\\)$@#\\1\\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/science-packages-24 science stable@' \$PREFIX/etc/apt/sources.list.d/science.list && apt update && apt upgrade \n"
+    public val QH:String = "sed -i 's@^\(deb.*stable main\)$@#\1\ndeb https://mirrors.tuna.tsinghua.edu.cn/termux/apt/termux-main stable main@' $PREFIX/etc/apt/sources.list && apt update && apt upgrade \n"
     public val BJ:String = "sed -i 's@^\\(deb.*stable main\\)$@#\\1\\ndeb https://mirrors.bfsu.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list &&" +
-        "sed -i 's@^\\(deb.*games stable\\)$@#\\1\\ndeb https://mirrors.bfsu.edu.cn/termux/game-packages-24 games stable@' \$PREFIX/etc/apt/sources.list.d/game.list &&" +
-        "sed -i 's@^\\(deb.*science stable\\)$@#\\1\\ndeb https://mirrors.bfsu.edu.cn/termux/science-packages-24 science stable@' \$PREFIX/etc/apt/sources.list.d/science.list &&" +
         "apt update && apt upgrade \n"
-    public val NJU:String = "sed -i 's@^\\(deb.*stable main\\)\$@#\\1\\ndeb https://mirror.nju.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list &&" +
-        "sed -i 's@^\\(deb.*games stable\\)\$@#\\1\\ndeb https://mirror.nju.edu.cn/termux/game-packages-24 games stable@' \$PREFIX/etc/apt/sources.list.d/game.list &&" +
-        "sed -i 's@^\\(deb.*science stable\\)\$@#\\1\\ndeb https://mirror.nju.edu.cn/termux/science-packages-24 science stable@' \$PREFIX/etc/apt/sources.list.d/science.list &&" +
+    public val NJU:String = "sed -i 's@^\\(deb.*stable main\\)\$@#\\1\\ndeb https://mirror.nju.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list &&" + +
         "apt update && apt upgrade \n"
-    public val USTC:String = "sed -i 's@packages.termux.org@mirrors.ustc.edu.cn/termux@' \$PREFIX/etc/apt/sources.list &&" +
+    public val USTC:String = "sed -i 's@^\\(deb.*stable main\\)$@#\\1\\ndeb https://mirrors.ustc.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list &&" +
         "pkg up \n"
     public val HEB:String = "sed -i 's@^\\(deb.*stable main\\)\$@#\\1\\ndeb https://mirrors.hit.edu.cn/termux/termux-packages-24 stable main@' \$PREFIX/etc/apt/sources.list &&" +
-        "sed -i 's@^\\(deb.*games stable\\)\$@#\\1\\ndeb https://mirrors.hit.edu.cn/termux/game-packages-24 games stable@' \$PREFIX/etc/apt/sources.list.d/game.list &&" +
-        "sed -i 's@^\\(deb.*science stable\\)\$@#\\1\\ndeb https://mirrors.hit.edu.cn/termux/science-packages-24 science stable@' \$PREFIX/etc/apt/sources.list.d/science.list &&" +
         "apt update && apt upgrade \n"
     public val UpDate:String = "pkg update -y \n"
     public val runLinuxSh:String = "cd ~ && cd ~ && chmod 777 linux.sh && ./linux.sh \n"


### PR DESCRIPTION
推荐直接使用`termux-change-repo`进行换源，原因： 国内源太多了。
国内源：
https://github.com/termux/termux-packages/wiki/Mirrors#mirrors-hosted-in-china
https://github.com/termux/termux-packages/issues/10635
https://github.com/termux/termux-packages/issues/10411
https://github.com/termux/termux-packages/issues/10400
https://github.com/termux/termux-packages/issues/10379
https://github.com/termux/termux-packages/issues/10691
https://github.com/termux/termux-packages/issues/10714

加起来有14个源

game.list  science.list unstable.list合并到sources.list

root-repo 和 x11-repo需要额外安装和换源，[termux-packages](https://github.com/termux/termux-packages/issues/9915)已经合并

![PUUB@NK47)ST2@LPI G0 MA](https://user-images.githubusercontent.com/57583560/169540763-d5db845f-f4b9-4483-aaad-02179ba08d14.jpg)

