### PR TITLE
优化build.gradle，新增action工作流喵

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,125 @@
+name: 编译ZeroTermux
+
+on:
+  push:
+    branches: [ "main", "master" ]
+    tags:
+      - 'ZeroTermux-*'
+      - 'v*'
+      - '[0-9]*'
+  pull_request:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: 配置 JDK 17 (用于 SDK 工具)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: 配置隔离的 Android SDK 环境
+        run: |
+          export NEW_SDK_ROOT=${{ github.workspace }}/custom-android-sdk
+          mkdir -p $NEW_SDK_ROOT
+          
+          echo "Created isolated SDK root at: $NEW_SDK_ROOT"
+
+          yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$NEW_SDK_ROOT \
+            "platform-tools" \
+            "platforms;android-33" \
+            "build-tools;30.0.2" \
+            "ndk;27.0.12077973"  \
+            "ndk;22.1.7171670"
+
+          cp -r ${ANDROID_HOME}/licenses $NEW_SDK_ROOT/
+          
+          echo "ANDROID_HOME=$NEW_SDK_ROOT" >> $GITHUB_ENV
+          echo "ANDROID_SDK_ROOT=$NEW_SDK_ROOT" >> $GITHUB_ENV
+
+      - name: 配置 JDK 11 (用于编译)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: 给 gradlew 执行权限
+        run: chmod +x gradlew
+
+      - name: 编译 Debug 和 Release 的 APK
+        run: ./gradlew assembleDebug assembleRelease --stacktrace
+
+      - name: 确定应用名称前缀
+        id: set_name
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            echo "APP_NAME=$TAG_NAME" >> $GITHUB_ENV
+            echo "Detected Tag: $TAG_NAME"
+          else
+            echo "APP_NAME=ZeroTermux-Nightly" >> $GITHUB_ENV
+            echo "Detected Branch build, using default name."
+          fi
+
+      - name: 重命名 APK 文件
+        run: |
+          echo "正在将文件名中的 'app' 替换为 '${{ env.APP_NAME }}' ..."
+          
+          # 查找所有以 app- 开头的 apk 文件
+          find app/build/outputs/apk -type f -name "app-*.apk" | while read file; do
+          
+            dir=$(dirname "$file")
+            filename=$(basename "$file")
+            new_filename="${filename/app/${{ env.APP_NAME }}}"
+          
+            mv "$file" "$dir/$new_filename"
+            echo "已重命名: $filename -> $new_filename"
+          done
+
+      - name: 上传 APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ZeroTermux-All-APKs
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/apk/debug/*.apk
+
+      - name: 更新 Nightly
+        uses: softprops/action-gh-release@v2
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        with:
+          tag_name: nightly
+          name: Nightly Build
+          prerelease: true
+          overwrite: true
+          files: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/apk/debug/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 创建正式发布
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: false
+          prerelease: false
+          files: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/apk/debug/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,6 +184,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -232,7 +233,7 @@ dependencies {
     implementation files('libs/mina-core-2.0.16.jar')
     implementation files('libs/slf4j-api-1.7.21.jar')
     implementation files('libs/slf4j-log4j12-1.7.21.jar')
-    implementation files('libs\\commons-codec-1.10-rep.jar')
+    implementation files('libs/commons-codec-1.10-rep.jar')
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.robolectric:robolectric:4.4"
@@ -259,7 +260,7 @@ def downloadBootstrap(String arch, String expectedChecksum, String version) {
             if (readBytes < 0) break
             digest.update(buffer, 0, readBytes)
         }
-        def checksum = new BigInteger(1, digest.digest()).toString(16)
+        def checksum = new BigInteger(1, digest.digest()).toString(16).padLeft(64, '0')
         if (checksum == expectedChecksum) {
             return
         } else {
@@ -280,7 +281,7 @@ def downloadBootstrap(String arch, String expectedChecksum, String version) {
     out << digestStream
     out.close()
 
-    def checksum = new BigInteger(1, digest.digest()).toString(16)
+    def checksum = new BigInteger(1, digest.digest()).toString(16).padLeft(64, '0')
     if (checksum != expectedChecksum) {
         file.delete()
         throw new GradleException("Wrong checksum for " + remoteUrl + ": expected: " + expectedChecksum + ", actual: " + checksum)
@@ -297,18 +298,18 @@ clean {
 
 task downloadBootstraps() {
     doLast {
-        def version = "2025.11.23-r1+apt.android-7"
-        downloadBootstrap("aarch64", "bec3e2b674b6efee7ff0e2a12824eb376e3fe182cc424d3357dad72c7cdd20d5", version)
-        downloadBootstrap("arm", "8c0487ed2e9a5a43af8347646b93641ed64939c532136cd2bc8df57eed5430b0", version)
-        downloadBootstrap("i686", "43df622bc3ce19583a18d1ec89f78ed990d0a0297d24e631141817e6a17a31c", version)
-        downloadBootstrap("x86_64", "8b36eafb6bf25ae32dd1646ddd5fe5b614510b68509df4eecf5a3e66409fc7f6", version)
+        def version = "2025.12.14-r1+apt.android-7"
+        downloadBootstrap("aarch64", "0e7d6ff8f99fb8ffe46df3174ec9e86e29491d5241fffc7872ae4c644257cb78", version)
+        downloadBootstrap("arm", "d2d27986de1900c89aa197e24c9c23d991238634e9fe79fb84046a61d5f8c5f2", version)
+        downloadBootstrap("i686", "2987b72ac7a78cb688d22be2d541e22e9fa92fb8566a1007aa58bb62e2482edd", version)
+        downloadBootstrap("x86_64", "3e85b11c0029e5b1a31632d73637f613779aceaf475beeaa8b411fddd09136c8", version)
     }
 }
 
 
 afterEvaluate {
     android.applicationVariants.all { variant ->
-        variant.javaCompileProvider.get().dependsOn(downloadBootstraps)
+        variant.preBuildProvider.get().dependsOn(downloadBootstraps)
     }
 }
 repositories {


### PR DESCRIPTION
#### 新增Actions Android构建工作流（比 #67 那个好用，我觉得有个workflow方便很多）
- 可以通过push(main)，pr(main)，tag(包括`ZeroTermux-`前缀)，还有手动来触发    
- 使用隔离的android sdk根目录 (platform-tools，android-33，build-tools 30.0.2， ndk27+22)，避免用runner自带的sdk（会出现`NumberFormatException: Not a number: 34x`报错）    
- 构建debug/release的apk，并上传到artifact（github为了节省空间所以传在artifact的是zip）    
- 当main变动会自动更新`nightly`prerelease    
打tag（`包括ZeroTermux-`前缀）则自动创建正式release并上传     
- 上传的构建产物apk自动重命名，使用tag作为前缀

#### 优化build.gradle
- release增加 `signingConfig signingConfigs.release`签名    
- 修改jar依赖路径分隔符（兼容Linux开发环境）    
- 更新bootstrap版本与checksum    
- sha256校验增加`padLeft(64, '0')`，避免开头 0 导致校验失败    
- 将bootstrap下载依赖挂到 `preBuild`，确保所有构建开始前执行    

本地`./gradlew assembleDebug assembleRelease`和GitHub Actions workflow 均通过（debug/release都有apk产出）    