### PR TITLE
完善语言切换体验,菜单配置智能更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,6 +113,8 @@ android {
         implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
         implementation 'com.mallotec.reb:plugin-locale:1.0.12'
+
+        implementation 'org.jsoup:jsoup:1.22.1'
         // @}
 //        implementation project(":FHttpServer")
         //       implementation project(":z_file")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -139,3 +139,6 @@
 -keep class * implements android.os.Parcelable {
     public static final ** CREATOR;
 }
+# Jsoup
+-keep class org.jsoup.** { *; }
+-dontwarn org.jsoup.**

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -1926,6 +1926,7 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
     }
 
     private void initMenu() {
+        writerMainMenuConfig(false);
         ZTUserBean ztUserBean = UserSetManage.Companion.get().getZTUserBean();
         if (ztUserBean.isDisableMainConfigMenu()) {
             initListMenu(MainMenuConfig.getMainMenuCategoryDatas());
@@ -1936,15 +1937,24 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
 
     private void writerMainMenuConfig(boolean cover) {
         File mainMenuXmlPathFile = FileIOUtils.INSTANCE.getMainMenuXmlPathFile();
+        Locale systemLocale = getResources().getConfiguration().locale;
+        String language = systemLocale.getLanguage();
+        String targetLang = (!TextUtils.isEmpty(language) && language.equals("en")) ? "en" : "cn";
+
         if (!mainMenuXmlPathFile.exists() || cover) {
-            Locale systemLocale = Locale.getDefault();
-            String language = systemLocale.getLanguage();
-            Log.i(TAG, "writerMainMenuConfig language: " + language);
-            Log.i(TAG, "writerMainMenuConfig language.equals(\"en\"): " + language.equals("en"));
-            if (!TextUtils.isEmpty(language) && language.equals("en")) {
+            Log.i(TAG, "writerMainMenuConfig create new file for language: " + targetLang);
+            if ("en".equals(targetLang)) {
                 UUtils.writerFile("mainmenu/en/zt_menu_config.xml", mainMenuXmlPathFile);
             } else {
                 UUtils.writerFile("mainmenu/cn/zt_menu_config.xml", mainMenuXmlPathFile);
+            }
+        } else {
+            Log.i(TAG, "writerMainMenuConfig smart update for language: " + targetLang);
+            try {
+                com.termux.zerocore.utils.XMLMergeUtils.smartUpdateMenuLanguage(this, targetLang);
+            } catch (Throwable e) {
+                Log.e(TAG, "Critical Error: XMLMergeUtils failed!", e);
+                e.printStackTrace();
             }
         }
     }

--- a/app/src/main/java/com/termux/zerocore/config/mainmenu/config/LanguageClickConfig.java
+++ b/app/src/main/java/com/termux/zerocore/config/mainmenu/config/LanguageClickConfig.java
@@ -11,6 +11,7 @@ import com.example.xh_lib.utils.LogUtils;
 import com.example.xh_lib.utils.UUtils;
 import com.mallotec.reb.localeplugin.utils.LocaleHelper;
 import com.termux.R;
+import com.termux.app.TermuxActivity;
 import com.termux.zerocore.popuwindow.MenuLeftPopuListWindow;
 
 import org.jetbrains.annotations.Nullable;
@@ -68,6 +69,10 @@ public class LanguageClickConfig extends BaseMenuClickConfig implements MenuLeft
                 LocaleHelper.Companion.getInstance()
                     .language(getLocale("1")).apply(mContext);
                 break;
+        }
+
+        if (mContext instanceof TermuxActivity) {
+            ((TermuxActivity) mContext).restartActivity();
         }
     }
 

--- a/app/src/main/java/com/termux/zerocore/utils/XMLMergeUtils.java
+++ b/app/src/main/java/com/termux/zerocore/utils/XMLMergeUtils.java
@@ -1,0 +1,144 @@
+package com.termux.zerocore.utils;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.example.xh_lib.utils.UUtils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Entities;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class XMLMergeUtils {
+
+    private static final String TAG = "XMLMergeUtils";
+
+    public static void smartUpdateMenuLanguage(Context context, String targetLang) {
+        String targetAssetPath;
+        String sourceAssetPath;
+
+        if ("en".equalsIgnoreCase(targetLang)) {
+            targetAssetPath = "mainmenu/en/zt_menu_config.xml";
+            sourceAssetPath = "mainmenu/cn/zt_menu_config.xml";
+        } else {
+            targetAssetPath = "mainmenu/cn/zt_menu_config.xml";
+            sourceAssetPath = "mainmenu/en/zt_menu_config.xml";
+        }
+
+        File userFile = FileIOUtils.INSTANCE.getMainMenuXmlPathFile();
+        if (!userFile.exists()) {
+            Log.i(TAG, "User file not exists, create new one from assets: " + targetAssetPath);
+            UUtils.writerFile(targetAssetPath, userFile);
+            return;
+        }
+
+        try {
+            Log.i(TAG, "Start smart merging. Target: " + targetLang);
+
+            Map<String, String> clickToTargetName = new HashMap<>();
+            Map<String, String> clickToTargetGroupName = new HashMap<>();
+            parseAssetFile(context, targetAssetPath, clickToTargetName, clickToTargetGroupName);
+
+            Map<String, String> clickToSourceName = new HashMap<>();
+            Map<String, String> clickToSourceGroupName = new HashMap<>();
+            parseAssetFile(context, sourceAssetPath, clickToSourceName, clickToSourceGroupName);
+
+            Document userDoc;
+            try (FileInputStream fis = new FileInputStream(userFile)) {
+                userDoc = Jsoup.parse(fis, "UTF-8", "", Parser.xmlParser());
+            }
+
+            int updatedItems = 0;
+            int updatedGroups = 0;
+
+            Elements userGroups = userDoc.select("group");
+            for (Element group : userGroups) {
+                String userGroupName = group.attr("name").trim();
+                Elements groupItems = group.select("item");
+
+                for (Element item : groupItems) {
+                    String click = item.attr("click").trim();
+
+                    if (clickToTargetGroupName.containsKey(click) && clickToSourceGroupName.containsKey(click)) {
+                        String targetGroupName = clickToTargetGroupName.get(click);
+                        String sourceGroupName = clickToSourceGroupName.get(click);
+
+                        if (userGroupName.equals(targetGroupName) || userGroupName.equals(sourceGroupName)) {
+                            if (!userGroupName.equals(targetGroupName)) {
+                                group.attr("name", targetGroupName);
+                                updatedGroups++;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            Elements userItems = userDoc.select("item");
+            for (Element item : userItems) {
+                String click = item.attr("click").trim();
+                String userName = item.attr("name").trim();
+
+                if (clickToTargetName.containsKey(click) && clickToSourceName.containsKey(click)) {
+                    String targetName = clickToTargetName.get(click);
+                    String sourceName = clickToSourceName.get(click);
+
+                    if (userName.equals(targetName) || userName.equals(sourceName)) {
+                         if (!userName.equals(targetName)) {
+                             item.attr("name", targetName);
+                             updatedItems++;
+                         }
+                    }
+                }
+            }
+
+            Log.i(TAG, "Merge finished. Updated " + updatedGroups + " groups and " + updatedItems + " items.");
+
+            userDoc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+            userDoc.outputSettings().prettyPrint(false);
+            userDoc.outputSettings().charset("UTF-8");
+            userDoc.outputSettings().escapeMode(Entities.EscapeMode.xhtml);
+            UUtils.setFileString(userFile, userDoc.outerHtml());
+
+        } catch (Exception e) {
+            Log.e(TAG, "Smart merge failed", e);
+            e.printStackTrace();
+        }
+    }
+
+    private static void parseAssetFile(Context context, String assetPath,
+                                     Map<String, String> clickToNameMap,
+                                     Map<String, String> clickToGroupNameMap) throws Exception {
+        try (InputStream is = context.getAssets().open(assetPath)) {
+            Document doc = Jsoup.parse(is, "UTF-8", "", Parser.xmlParser());
+
+            Elements groups = doc.select("group");
+            for (Element group : groups) {
+                String groupName = group.attr("name").trim();
+                Elements items = group.select("item");
+                for (Element item : items) {
+                    String click = item.attr("click").trim();
+                    String name = item.attr("name").trim();
+                    if (!TextUtils.isEmpty(click)) {
+                        if (!TextUtils.isEmpty(name)) {
+                            clickToNameMap.put(click, name);
+                        }
+                        if (!TextUtils.isEmpty(groupName)) {
+                            clickToGroupNameMap.put(click, groupName);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
新增 XMLMergeUtils ，使用 Jsoup 解析和操作 XML 配置文件，基于 click 属性作为唯一标识的菜单项匹配逻辑，在切换语言时会对比当前配置文件与默认语言包。仅当菜单项名称与默认的中/英文名称一致时，才会自动更新为目标语言，如果用户已自定义修改了菜单名称，则保留用户配置，不覆盖
<del>（就我是之前在群里和您说的那个，看您没有回复，不知道您有什么看法，所以就此开一个）</del>