### PR TITLE
修复 TermuxActivity 可能发生的 NullPointerException

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -2558,9 +2558,11 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
             localBroadcastManager.unregisterReceiver(localReceiver);
             localBroadcastManager.unregisterReceiver(messageReceiver);
         }
-        if (mMainMenuAdapter != null) {
-            mMainMenuAdapter.release();
+        MainMenuAdapter adapter = mMainMenuAdapter;
+        if (adapter != null) {
+            adapter.release();
         }
+        mMainMenuAdapter = null;
         VideoUtils.getInstance().onDestroy();
         if (mInternalPassage && mMainActivity != null) {
             mMainActivity.onDestroy(this);


### PR DESCRIPTION
用局部变量 adapter 暂存成员变量引用后再判空，避免多线程并发修改导致成员变量在中途被置空从而引发 Crash