### PR TITLE
同步上游：将终端读取缓冲区提升到 64KB

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -41,7 +41,7 @@ public final class TerminalSession extends TerminalOutput {
      * A queue written to from a separate thread when the process outputs, and read by main thread to process by
      * terminal emulator.
      */
-    final ByteQueue mProcessToTerminalIOQueue = new ByteQueue(4096);
+    final ByteQueue mProcessToTerminalIOQueue = new ByteQueue(64 * 1024);
     /**
      * A queue written to from the main thread due to user interaction, and read by another thread which forwards by
      * writing to the {@link #mTerminalFileDescriptor}.
@@ -336,7 +336,7 @@ public final class TerminalSession extends TerminalOutput {
     @SuppressLint("HandlerLeak")
     class MainThreadHandler extends Handler {
 
-        final byte[] mReceiveBuffer = new byte[4 * 1024];
+        final byte[] mReceiveBuffer = new byte[64 * 1024];
 
         @Override
         public void handleMessage(Message msg) {


### PR DESCRIPTION
摘取 termux-app 上游提交中的对应补丁，将终端输出队列和主线程接收缓冲区从 4KB 提升到 64KB。

小缓冲区在大内容场景下容易造成明显卡顿，例如终端复用器中的滚动。

Upstream-Commit: https://github.com/termux/termux-app/commit/ef4775b651c752d5876991a403ecad58bc1fb118

Original-Subject: Increase read buffer size from 4KB to 64KB