### PR TITLE
同步上游：补齐 manifest 兼容性并接入文件入口开关

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.DUMP" />
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -156,6 +157,7 @@
 
         <activity
             android:name=".app.TermuxActivity"
+            android:exported="true"
             android:configChanges="orientation|screenSize|smallestScreenSize|density|screenLayout|uiMode|keyboard|keyboardHidden|navigation"
             android:label="@string/app_name"
             android:launchMode="singleTask"
@@ -280,11 +282,19 @@
         <activity
             android:name=".filepicker.TermuxFileReceiverActivity"
             android:excludeFromRecents="true"
+            android:exported="false"
             android:label="@string/opne_in_zerotermux"
             android:noHistory="true"
             android:resizeableActivity="true"
             android:taskAffinity="${TERMUX_PACKAGE_NAME}.filereceiver"
-            android:theme="@style/Theme.AppCompat.NoActionBar">
+            android:theme="@style/Theme.AppCompat.NoActionBar" />
+
+        <activity-alias
+            android:name=".filepicker.TermuxFileShareReceiverActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:label="@string/opne_in_zerotermux"
+            android:targetActivity=".filepicker.TermuxFileReceiverActivity">
 
             <!-- Accept multiple file types when sending. -->
             <intent-filter>
@@ -300,6 +310,15 @@
                 <data android:mimeType="text/*" />
                 <data android:mimeType="video/*" />
             </intent-filter>
+        </activity-alias>
+
+        <activity-alias
+            android:name=".filepicker.TermuxFileViewReceiverActivity"
+            android:enabled="true"
+            android:exported="true"
+            android:label="@string/opne_in_zerotermux"
+            android:targetActivity=".filepicker.TermuxFileReceiverActivity">
+
             <!-- Accept multiple file types to let Termux be usable as generic file viewer. -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
@@ -312,7 +331,7 @@
                 <data android:mimeType="text/*" />
                 <data android:mimeType="video/*" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <provider
             android:name=".filepicker.TermuxDocumentsProvider"
@@ -338,7 +357,16 @@
             </intent-filter>
         </service>
 
-        <receiver android:name=".app.TermuxOpenReceiver" />
+        <receiver
+            android:name=".app.TermuxOpenReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".app.event.SystemEventReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <service android:name=".zerocore.config.ztcommand.ZTSocketService"/>
 
         <service android:name=".zerocore.ftp.FsService" />

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -68,7 +68,7 @@ import com.hjq.permissions.Permission;
 import com.hjq.permissions.XXPermissions;
 import com.lzy.okgo.model.Response;
 import com.termux.R;
-import com.termux.app.api.file.FileReceiverActivity;
+import com.termux.filepicker.TermuxFileReceiverActivity;
 import com.termux.app.terminal.TermuxActivityRootView;
 import com.termux.app.terminal.TermuxTerminalSessionActivityClient;
 import com.termux.app.terminal.io.TermuxTerminalExtraKeys;
@@ -368,7 +368,7 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
 
         registerForContextMenu(mTerminalView);
 
-        FileReceiverActivity.updateFileReceiverActivityComponentsState(this);
+        TermuxFileReceiverActivity.updateReceiverComponentsState(this);
 
         try {
             // Start the {@link TermuxService} and make it run regardless of who is bound to it
@@ -1172,7 +1172,7 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         setMargins();
         setTerminalToolbarHeight();
 
-        FileReceiverActivity.updateFileReceiverActivityComponentsState(this);
+        TermuxFileReceiverActivity.updateReceiverComponentsState(this);
 
         if (mTermuxTerminalSessionActivityClient != null)
             mTermuxTerminalSessionActivityClient.onReloadActivityStyling();

--- a/app/src/main/java/com/termux/filepicker/TermuxFileReceiverActivity.kt
+++ b/app/src/main/java/com/termux/filepicker/TermuxFileReceiverActivity.kt
@@ -1,9 +1,11 @@
 package com.termux.filepicker
 
+import android.content.Intent
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import android.provider.OpenableColumns
 import android.provider.MediaStore
 import android.view.View
 import android.widget.ImageView
@@ -19,6 +21,11 @@ import com.hjq.permissions.Permission
 import com.hjq.permissions.XXPermissions
 import com.termux.R
 import com.termux.app.TermuxInstaller
+import com.termux.shared.android.PackageUtils
+import com.termux.shared.logger.Logger
+import com.termux.shared.termux.TermuxConstants
+import com.termux.shared.termux.TermuxConstants.TERMUX_APP
+import com.termux.shared.termux.settings.properties.TermuxAppSharedProperties
 import com.termux.zerocore.utils.FileIOUtils
 import com.zp.z_file.bean.DataBean
 import com.zp.z_file.ui.dialog.InstallModuleDialog
@@ -40,20 +47,99 @@ class TermuxFileReceiverActivity : ComponentActivity() {
     private val image_view: ImageView by lazy { findViewById(R.id.image_view) }
     private val pro: ProgressBar by lazy { findViewById(R.id.pro) }
     private var mFile: File? = null
+    private var incomingFileName: String? = null
 
+    companion object {
+        private const val LOG_TAG = "TermuxFileReceiverActivity"
+
+        @JvmStatic
+        fun updateReceiverComponentsState(context: Context) {
+            Thread {
+                val properties = TermuxAppSharedProperties.getProperties() ?: return@Thread
+
+                var errorMessage: String?
+
+                val shareState = !properties.isFileShareReceiverDisabled()
+                Logger.logVerbose(LOG_TAG, "Setting ${TERMUX_APP.FILE_SHARE_RECEIVER_ACTIVITY_CLASS_NAME} component state to $shareState")
+                errorMessage = PackageUtils.setComponentState(
+                    context,
+                    TermuxConstants.TERMUX_PACKAGE_NAME,
+                    TERMUX_APP.FILE_SHARE_RECEIVER_ACTIVITY_CLASS_NAME,
+                    shareState,
+                    null,
+                    false,
+                    false
+                )
+                if (errorMessage != null) {
+                    Logger.logError(LOG_TAG, errorMessage)
+                }
+
+                val viewState = !properties.isFileViewReceiverDisabled()
+                Logger.logVerbose(LOG_TAG, "Setting ${TERMUX_APP.FILE_VIEW_RECEIVER_ACTIVITY_CLASS_NAME} component state to $viewState")
+                errorMessage = PackageUtils.setComponentState(
+                    context,
+                    TermuxConstants.TERMUX_PACKAGE_NAME,
+                    TERMUX_APP.FILE_VIEW_RECEIVER_ACTIVITY_CLASS_NAME,
+                    viewState,
+                    null,
+                    false,
+                    false
+                )
+                if (errorMessage != null) {
+                    Logger.logError(LOG_TAG, errorMessage)
+                }
+            }.start()
+        }
+    }
+
+    private fun resolveIncomingUri(): Uri? {
+        val intent = intent ?: return null
+        return if (Intent.ACTION_SEND == intent.action) {
+            intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: intent.data
+        } else {
+            intent.data
+        }
+    }
+
+    private fun resolveIncomingDisplayName(uri: Uri?): String? {
+        if (uri == null) return null
+        try {
+            contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                val fileNameColumnId = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (fileNameColumnId >= 0 && cursor.moveToFirst()) {
+                    return cursor.getString(fileNameColumnId)
+                }
+            }
+        } catch (e: Exception) {
+            LogUtils.d(TAG, "resolveIncomingDisplayName error: $e")
+        }
+        return uri.lastPathSegment
+    }
+
+    private fun resolveEffectiveFileName(displayName: String?, file: File): String {
+        val normalizedDisplayName = displayName?.let { File(it).name }?.takeIf { it.isNotBlank() }
+        return normalizedDisplayName ?: file.name
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_termux_file_receiver)
         try {
-            val realPathFromURI = UUtils.getFileAbsolutePath(this, intent?.data)
+            val incomingUri = resolveIncomingUri()
+            val realPathFromURI = UUtils.getFileAbsolutePath(this, incomingUri)
+            if (realPathFromURI.isNullOrEmpty()) {
+                UUtils.showMsg(UUtils.getString(R.string.copy_uri_error))
+                finish()
+                return
+            }
             realPathFromURI.let {
                 mFile = File(it)
-                /*        if (FileIOUtils.isPacketFormat(mFile!!.name)) {
-                            install_data.visibility = View.VISIBLE
-                        } else {
-                            install_data.visibility = View.GONE
-                        }*/
+                incomingFileName = resolveEffectiveFileName(resolveIncomingDisplayName(incomingUri), mFile!!)
+                if (FileIOUtils.isPacketFormat(mFile!!.name)) {
+                    install_data.visibility = View.VISIBLE
+                } else {
+                    install_data.visibility = View.GONE
+                }
 
                 if (FileIOUtils.isModuleFormat(mFile!!.name)) {
                     install_module.visibility = View.VISIBLE
@@ -91,13 +177,13 @@ class TermuxFileReceiverActivity : ComponentActivity() {
                 val lengthToMb = FileIOUtils.getLengthToMb(mFile!!)
                 if (lengthToMb != null) {
                     msg_file.text = UUtils.getString(R.string.file_name_copy)
-                        .replace("{file}", mFile!!.name)
+                        .replace("{file}", incomingFileName ?: mFile!!.name)
                         .replace("{size}", lengthToMb)
                         .replace("{path}", mFile!!.absolutePath)
                         .replace("{suffix}", FileIOUtils.getExtension(mFile!!))
                 } else {
                     msg_file.text = UUtils.getString(R.string.file_name_copy)
-                        .replace("{file}", "N/A")
+                        .replace("{file}", incomingFileName ?: "N/A")
                         .replace("{size}", "N/A")
                         .replace("{path}", "N/A")
                         .replace("{suffix}", "N/A")
@@ -110,7 +196,7 @@ class TermuxFileReceiverActivity : ComponentActivity() {
                     finish()
                     return@setOnClickListener
                 }
-                val file = File(FileIOUtils.getHomePath(UUtils.getContext()), mFile!!.name)
+                val file = File(FileIOUtils.getHomePath(UUtils.getContext()), incomingFileName ?: mFile!!.name)
                 LogUtils.d(TAG, "onCreate file: ${file.absolutePath}")
                 if (!file.exists()) {
                     file.createNewFile()

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -927,11 +927,11 @@ public final class TermuxConstants {
         /** Termux app BuildConfig class name */
         public static final String BUILD_CONFIG_CLASS_NAME = TERMUX_PACKAGE_NAME + ".BuildConfig"; // Default: "com.termux.BuildConfig"
 
-        /** Termux app FileShareReceiverActivity class name */
-        public static final String FILE_SHARE_RECEIVER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".app.api.file.FileShareReceiverActivity"; // Default: "com.termux.app.api.file.FileShareReceiverActivity"
+        /** ZeroTermux file share receiver alias class name */
+        public static final String FILE_SHARE_RECEIVER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".filepicker.TermuxFileShareReceiverActivity"; // Default: "com.termux.filepicker.TermuxFileShareReceiverActivity"
 
-        /** Termux app FileViewReceiverActivity class name */
-        public static final String FILE_VIEW_RECEIVER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".app.api.file.FileViewReceiverActivity"; // Default: "com.termux.app.api.file.FileViewReceiverActivity"
+        /** ZeroTermux file view receiver alias class name */
+        public static final String FILE_VIEW_RECEIVER_ACTIVITY_CLASS_NAME = TERMUX_PACKAGE_NAME + ".filepicker.TermuxFileViewReceiverActivity"; // Default: "com.termux.filepicker.TermuxFileViewReceiverActivity"
 
 
         /** Termux app core activity name. */


### PR DESCRIPTION
同步上游 AndroidManifest 兼容性改动，补齐 BOOT_COMPLETED、TermuxActivity exported、TermuxOpenReceiver exported 和 SystemEventReceiver。

文件接收继续用 ZeroTermux 自己的 TermuxFileReceiverActivity 处理，但入口结构改成上游同类的 alias 模式，把分享入口和查看入口拆开，并接入上游的 disable-file-share-receiver / disable-file-view-receiver 配置项。这部分主要参考上游 af6ac30bb1b062ccca5813e65380c8cafe20eaa3。

同时修复分享文件兼容性：ACTION_SEND 优先取 EXTRA_STREAM，没有就回退 intent.data；优先用 DISPLAY_NAME，当作界面显示名和复制到 $HOME 的目标名，避免 content:// 被缓存后带随机前缀。

用法：
在 ~/.termux/termux.properties 或 ~/.config/termux/termux.properties 里加：
- disable-file-share-receiver=true  禁用“分享给 ZeroTermux”
- disable-file-view-receiver=true  禁用“用 ZeroTermux 打开”

Upstream-Commit: https://github.com/termux/termux-app/commit/2452399a13051065f8c19e5b3c023320a4ebbeba

Upstream-Commit: https://github.com/termux/termux-app/commit/150b1ff99c280dac09209b16c4149d3accf39591

Upstream-Commit: https://github.com/termux/termux-app/commit/d39972b3bfe3361c1437e5faaf6ea8ffbcb0d8ef

Upstream-Commit: https://github.com/termux/termux-app/commit/af6ac30bb1b062ccca5813e65380c8cafe20eaa3
Original-Subject: Added: Allow users to disable termux file view and share receivers