### PR TITLE
fix(terminal): 兜底处理终端通信监听为空

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ android {
         // versionCode 118
         // versionName "0.118.0"
         versionCode 117
-        versionName "0.118.3.55"
+        versionName "0.118.3.56"
         // @}
         if (appVersionName) versionName = appVersionName
         validateVersionName(versionName)

--- a/app/src/main/java/com/termux/zerocore/utils/SingletonCommunicationUtils.java
+++ b/app/src/main/java/com/termux/zerocore/utils/SingletonCommunicationUtils.java
@@ -1,11 +1,40 @@
 package com.termux.zerocore.utils;
 
 import com.example.xh_lib.utils.LogUtils;
+import com.example.xh_lib.utils.UUtils;
+import com.termux.R;
 
 public class SingletonCommunicationUtils {
     private static final String TAG = SingletonCommunicationUtils.class.getSimpleName();
     private static SingletonCommunicationUtils singletonCommunicationUtils;
     public static boolean isSingletonCommunicationListenerNull = true;
+    private static final SingletonCommunicationListener EMPTY_SINGLETON_COMMUNICATION_LISTENER = new SingletonCommunicationListener() {
+        @Override
+        public void sendTextToTerminal(String command) {
+            notifyTerminalUnavailable("sendTextToTerminal", command, R.string.zt_terminal_unavailable_command_not_sent);
+        }
+
+        @Override
+        public void sendTextToTerminalAlt(String command, boolean isAlt) {
+            notifyTerminalUnavailable("sendTextToTerminalAlt", command + ", isAlt: " + isAlt, R.string.zt_terminal_unavailable_command_not_sent);
+        }
+
+        @Override
+        public void sendTextToTerminalCtrl(String command, boolean isCtrl) {
+            notifyTerminalUnavailable("sendTextToTerminalCtrl", command + ", isCtrl: " + isCtrl, R.string.zt_terminal_unavailable_command_not_sent);
+        }
+
+        @Override
+        public void onTerminalExtraKeyButtonClick(String key) {
+            notifyTerminalUnavailable("onTerminalExtraKeyButtonClick", key, R.string.zt_terminal_unavailable_key_not_sent);
+        }
+
+        @Override
+        public String getTextToTerminal() {
+            notifyTerminalUnavailable("getTextToTerminal", null, R.string.zt_terminal_unavailable_text_not_read);
+            return "";
+        }
+    };
     private SingletonCommunicationListener mSingletonCommunicationListener;
     public static SingletonCommunicationUtils getInstance() {
         if (singletonCommunicationUtils == null) {
@@ -25,7 +54,15 @@ public class SingletonCommunicationUtils {
     }
 
     public SingletonCommunicationListener getmSingletonCommunicationListener() {
+        if (mSingletonCommunicationListener == null) {
+            return EMPTY_SINGLETON_COMMUNICATION_LISTENER;
+        }
         return mSingletonCommunicationListener;
+    }
+
+    private static void notifyTerminalUnavailable(String action, String content, int toastMessageResId) {
+        LogUtils.e(TAG, "terminal communication listener is null, action: " + action + ", content: " + content);
+        UUtils.showMsg(UUtils.getString(toastMessageResId));
     }
 
     public static interface SingletonCommunicationListener {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1284,6 +1284,9 @@ cd ~ &amp;&amp; pkg update -y \n
     <string name="zt_usage_habits_ztermux">ZeroTermux usage habit set successfully. Please go to settings to change the configuration.</string>
     <string name="zt_guide">Double-tap the edge of the screen to bring up the left/right menu bar\nIf you have set the ZT usage habit, use the Volume +\- keys\nIf the left/right sidebar cannot close this window\nLong press here to force close</string>
     <string name="zt_core_date_error">There is an error in the upper and lower data of the core terminal. Please return to the desktop and try again.</string>
+    <string name="zt_terminal_unavailable_command_not_sent">Terminal is not ready. Command was not sent.</string>
+    <string name="zt_terminal_unavailable_key_not_sent">Terminal is not ready. Key was not sent.</string>
+    <string name="zt_terminal_unavailable_text_not_read">Terminal is not ready. Unable to read terminal content.</string>
 
     <string name="deepseek_input_key_error_info_400">Possible issues: \n\nReturns 400 with no DeepSeek Key set or entered the wrong key</string>
     <string name="deepseek_input_key_error_info_401">Possible issues: 401 is returned, API key is wrong, authentication failed, Solution: Please check if your API key is correct</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1068,6 +1068,9 @@
     <string name="content_ssh_list_toast_hint">正在初始化中，请耐心等待...</string>
     <string name="content_ssh_list_toast_ssh_hint">初次使用，正在初始化SSH环境...</string>
     <string name="content_ssh_list_toast_ssh_wait">环境尚未就绪，请稍候...</string>
+    <string name="zt_terminal_unavailable_command_not_sent">终端未就绪，命令未发送</string>
+    <string name="zt_terminal_unavailable_key_not_sent">终端未就绪，按键未发送</string>
+    <string name="zt_terminal_unavailable_text_not_read">终端未就绪，无法读取终端内容</string>
     <string name="content_ssh_remove_device">删除设备</string>
     <string name="content_ssh_remove_device_dialog">"确定要删除'%s'吗？\n(IP: '%s')"</string>
     <string name="content_ssh_remove_ok">已删除</string>
@@ -1306,6 +1309,5 @@
     <string name="deepseek_input_key_error_info_503">可能的问题:\n\n返回503，服务器负载过高，解决方法：请稍后重试您的请求。</string>
     <string name="deepseek_input_key_error_info_other">可能的问题:\n\n返回未能识别的code，服务器可能本次请求断开了？，解决方法：请稍后重试您的请求。</string>
 </resources>
-
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1015,6 +1015,9 @@
     <string name="content_ssh_list_toast_hint">正在初始化中，请耐心等待...</string>
     <string name="content_ssh_list_toast_ssh_hint">初次使用，正在初始化SSH环境...</string>
     <string name="content_ssh_list_toast_ssh_wait">环境尚未就绪，请稍候...</string>
+    <string name="zt_terminal_unavailable_command_not_sent">终端未就绪，命令未发送</string>
+    <string name="zt_terminal_unavailable_key_not_sent">终端未就绪，按键未发送</string>
+    <string name="zt_terminal_unavailable_text_not_read">终端未就绪，无法读取终端内容</string>
     <string name="content_ssh_remove_device">删除设备</string>
     <string name="content_ssh_remove_device_dialog">"确定要删除'%s'吗？\n(IP: '%s')"</string>
     <string name="content_ssh_remove_ok">已删除</string>


### PR DESCRIPTION
为 SingletonCommunicationUtils 增加空监听器，避免 SSH 连接等入口在 TermuxActivity 生命周期切换后触发 NullPointerException。 当终端通信监听为空时记录日志并通过字符串资源提示用户，避免命令静默丢失。