### PR TITLE
feat: default -Darch=all now produces 5 APKs (universal + 4 ABIs)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[skip ci]') }}
     strategy:
       matrix:
-        arch: [all, arm, arm64, x86, x86_64]
+        arch: [universal, arm, arm64, x86, x86_64]
       fail-fast: false
     uses: ./.github/workflows/build.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - all
+          - universal
           - arm
           - arm64
           - x86
@@ -85,11 +86,12 @@ jobs:
         id: abi
         run: |
           case "${{ inputs.arch }}" in
-            all)    echo "abi=universal" >> $GITHUB_OUTPUT ;;
-            arm)    echo "abi=armeabi-v7a" >> $GITHUB_OUTPUT ;;
-            arm64)  echo "abi=arm64-v8a" >> $GITHUB_OUTPUT ;;
-            x86)    echo "abi=x86" >> $GITHUB_OUTPUT ;;
-            x86_64) echo "abi=x86_64" >> $GITHUB_OUTPUT ;;
+            all)       echo "abi=universal" >> $GITHUB_OUTPUT ;;
+            universal) echo "abi=universal" >> $GITHUB_OUTPUT ;;
+            arm)       echo "abi=armeabi-v7a" >> $GITHUB_OUTPUT ;;
+            arm64)     echo "abi=arm64-v8a" >> $GITHUB_OUTPUT ;;
+            x86)       echo "abi=x86" >> $GITHUB_OUTPUT ;;
+            x86_64)    echo "abi=x86_64" >> $GITHUB_OUTPUT ;;
           esac
 
       - name: 编译 APK (${{ inputs.arch }})

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,12 +154,16 @@ android {
     def buildArch = System.getProperty("arch", "all")
     splits {
         abi {
-            enable buildArch != "all"
-            reset()
-            if (buildArch == "all") {
+            if (buildArch == "universal") {
+                enable false
+            } else if (buildArch == "all") {
+                enable true
+                reset()
                 include "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
                 universalApk true
             } else {
+                enable true
+                reset()
                 def abi = buildArch == "arm" ? "armeabi-v7a" :
                           buildArch == "arm64" ? "arm64-v8a" :
                           buildArch == "x86" ? "x86" :
@@ -264,13 +268,8 @@ android {
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
-            if (variant.buildType.name == "debug") {
-                def abi = output.getFilter(com.android.build.OutputFile.ABI)
-                outputFileName = new File("termux-app_" + (apkVersionTag ? apkVersionTag : project.ext.packageVariant + "-" + "debug") + "_" + (abi ? abi : "universal") + ".apk")
-            } else if (variant.buildType.name == "release") {
-                def abi = output.getFilter(com.android.build.OutputFile.ABI)
-                outputFileName = new File("termux-app_" + (apkVersionTag ? apkVersionTag : project.ext.packageVariant + "-" + "release") + "_" + (abi ? abi : "universal") + ".apk")
-            }
+            def abi = output.getFilter(com.android.build.OutputFile.ABI) ?: "universal"
+            outputFileName = "ZeroTermux-${variant.versionName}_${variant.buildType.name}_${abi}.apk"
         }
     }
 

--- a/terminal-emulator/build.gradle
+++ b/terminal-emulator/build.gradle
@@ -19,7 +19,7 @@ android {
 
         ndk {
             def buildArch = System.getProperty("arch", "all")
-            if (buildArch == "all") {
+            if (buildArch == "universal" || buildArch == "all") {
                 abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             } else {
                 def abi = buildArch == "arm" ? "armeabi-v7a" :


### PR DESCRIPTION
- Default build (no -Darch) enables splits with all ABIs + universal
- -Darch=universal for universal-only APK
- -Darch=arm64/arm/x86/x86_64 for single-ABI APK
- CI matrix uses universal instead of all for the universal runner
- APK naming: ZeroTermux-{version}_{buildType}_{abi}.apk